### PR TITLE
Feat: Add automatic update functionality. Implement GitHub updater, add MinVer for versioning

### DIFF
--- a/EasyRCP.csproj
+++ b/EasyRCP.csproj
@@ -9,6 +9,14 @@
     <ApplicationIcon>RcpOnlineIcon.ico</ApplicationIcon>
   </PropertyGroup>
 
+  <PropertyGroup>
+    <NeutralLanguage>pl-PL</NeutralLanguage>
+  </PropertyGroup>
+
+  <PropertyGroup>
+    <MinVerTagPrefix>v</MinVerTagPrefix> <!-- Używane przez release-please -->
+  </PropertyGroup>
+
   <ItemGroup>
     <None Remove="RcpOnline.ico" />
     <None Remove="Resources\RcpOnlineIcon.ico" />
@@ -29,6 +37,10 @@
     
   <ItemGroup>
     <PackageReference Include="DotNetSeleniumExtras.WaitHelpers" Version="3.11.0" />
+    <PackageReference Include="MinVer" Version="6.0.0">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
     <PackageReference Include="Polly" Version="8.5.2" />
     <PackageReference Include="Selenium.Support" Version="4.31.0" />
     <PackageReference Include="Selenium.WebDriver" Version="4.31.0" />

--- a/Program.cs
+++ b/Program.cs
@@ -3,6 +3,7 @@ using EasyRCP.Services;
 using Microsoft.Win32;
 
 namespace EasyRCP;
+
 internal static class Program
 {
     /// <summary>
@@ -13,6 +14,9 @@ internal static class Program
     {
         try
         {
+            // Check for new application version and apply it if available
+            await GitHubUpdater.CheckVersionAndUpdateApplicationAsync();
+
             // To customize application configuration such as set high DPI settings or default font,
             // see https://aka.ms/applicationconfiguration.
             AddApplicationToStartup();

--- a/README.md
+++ b/README.md
@@ -6,4 +6,16 @@ CredentialsForm będzie odpalane jako dialog i będzie służyć tylko do wpisyw
 MainForm będzie jako Application Run i to będzie wiecznie ukryte okno, które będzie miało w tray'u wszystkie przyciski <br />
 TODO3: Pozbierać wszystkie try catche, żeby rzucały wyjątki do Program.cs <br />
 TODO4: Dodać polski język gdzieś w GHAction, bo sądziwne znaczki <br />
-TODO4: Dodać przycisk "Zakończ pracę" <br />
+
+# Automatyczna aktualizacja aplikacji przez GitHub Releases
+
+Aplikacja automatycznie sprawdza dostępność nowej wersji na podstawie najnowszego releasu w repozytorium GitHub. 
+Kolejne wydania aplikacji są tworzone i oznaczane tagami przez narzędzie **release-please**,  
+a wersjonowanie zarządzane jest przez narzędzie **MinVer**.
+
+Mechanizm aktualizacji:
+
+- Pobierany jest tag najnowszego release'u z GitHuba i porównywany z aktualną wersją aplikacji zarządzaną przez MinVer.
+- Jeśli dostępna jest nowsza wersja, aplikacja pobiera nowy plik `EasyRCP.exe` pod nazwą `EasyRCP_new.exe`.
+- Tworzy się i uruchamiany skrypt `update.bat`, który zatrzymuje działającą aplikację, usuwa stary plik, zamienia nowy na oryginalny i uruchamia aplikację ponownie.
+- Skrypt jest usuwany po wykonaniu, aby nie pozostawiać niepotrzebnych plików.

--- a/Services/GitHubUpdater.cs
+++ b/Services/GitHubUpdater.cs
@@ -1,0 +1,143 @@
+﻿using System.Diagnostics;
+using System.Reflection;
+using System.Text.Json.Serialization;
+using System.Text.Json;
+
+namespace EasyRCP.Services;
+
+/// <summary>
+/// Provides functionality to check for and apply updates from the latest GitHub release.
+/// </summary>
+public static class GitHubUpdater
+{
+    private const string GitHubApiUrl = "https://api.github.com/repos/mslowin/EasyRCP/releases/latest";
+
+    private const string ExecutableName = "EasyRCP.exe";
+
+    /// <summary>
+    /// Checks for a new release on GitHub and updates the application if a newer version is available.
+    /// Downloads the new executable and initiates a script to replace the running instance.
+    /// </summary>
+    /// <returns>A task representing the asynchronous operation.</returns>
+    public static async Task CheckVersionAndUpdateApplicationAsync()
+    {
+        var hasUpdateHappened = CheckIfUpdateScriptExists();
+        if (hasUpdateHappened)
+        {
+            return;
+        }
+
+        using var httpClient = new HttpClient();
+        httpClient.DefaultRequestHeaders.UserAgent.ParseAdd("EasyRCP");
+
+        var json = await httpClient.GetStringAsync(GitHubApiUrl);
+        var release = JsonSerializer.Deserialize<GitHubRelease>(json);
+
+        var currentAppVersion = Assembly.GetExecutingAssembly()
+            .GetCustomAttribute<AssemblyInformationalVersionAttribute>()?
+            .InformationalVersion?.Split('+')[0];
+
+        var latestAppVersion = release?.TagName?.TrimStart('v');
+
+        if (latestAppVersion != null && currentAppVersion != null && latestAppVersion != currentAppVersion)
+        {
+            var asset = release?.Assets?.Find(a => a.ApplicationName == ExecutableName);
+            if (asset != null)
+            {
+                MessageBox.Show(
+                    $"Znaleziono nową wersję aplikacji: {latestAppVersion}.\n" +
+                    $"Aktualna wersja to: {currentAppVersion}.\n" +
+                    $"Aplikacja zostanie zaktualizowana do najnowszej wersji.",
+                    "EasyRCP - nowa wersja",
+                    MessageBoxButtons.OK,
+                    MessageBoxIcon.Information);
+
+                var newExe = "EasyRCP_new.exe";
+                using var stream = await httpClient.GetStreamAsync(asset.AplicationDownloadUrl);
+                using var fs = File.Create(newExe);
+                await stream.CopyToAsync(fs);
+
+                CreateAndRunUpdateScript();
+                Application.Exit();
+            }
+        }
+    }
+
+    /// <summary>
+    /// Checks if an update script exists and, if so,
+    /// displays a message indicating that the application has been updated. Deletes the script after.
+    /// </summary>
+    /// <returns>True if the update script exists and was processed, false otherwise.</returns>
+    private static bool CheckIfUpdateScriptExists()
+    {
+        if (File.Exists("update.bat"))
+        {
+            MessageBox.Show(
+                "Aplikacja została zaktualizowana do najnowszej wersji i automatycznie się uruchomi.",
+                "EasyRCP - Aktualizacja zakończona",
+                MessageBoxButtons.OK,
+                MessageBoxIcon.Information);
+            File.Delete("update.bat");
+
+            return true;
+        }
+
+        return false;
+    }
+
+    /// <summary>
+    /// Creates a batch script to terminate the current process, replace the executable, and restart the application.
+    /// Executes the script in a new process.
+    /// </summary>
+    private static void CreateAndRunUpdateScript()
+    {
+        var script = """
+        taskkill /f /im EasyRCP.exe
+        timeout /t 2 /nobreak > NUL
+        del EasyRCP.exe
+        timeout /t 1 /nobreak > NUL
+        rename EasyRCP_new.exe EasyRCP.exe
+        timeout /t 1 /nobreak > NUL
+        start EasyRCP.exe
+        """;
+
+        File.WriteAllText("update.bat", script);
+        Process.Start(new ProcessStartInfo("cmd.exe", "/c update.bat") { CreateNoWindow = true });
+    }
+
+    /// <summary>
+    /// Represents a GitHub release with its tag and associated assets.
+    /// </summary>
+    private sealed class GitHubRelease
+    {
+        /// <summary>
+        /// Gets or sets the tag name of the release (e.g., "v1.2.3").
+        /// </summary>
+        [JsonPropertyName("tag_name")]
+        public string? TagName { get; set; }
+
+        /// <summary>
+        /// Gets or sets the list of assets attached to the release.
+        /// </summary>
+        [JsonPropertyName("assets")]
+        public List<GitHubAsset>? Assets { get; set; }
+    }
+
+    /// <summary>
+    /// Represents an asset in a GitHub release.
+    /// </summary>
+    private sealed class GitHubAsset
+    {
+        /// <summary>
+        /// Gets or sets the name of the asset (e.g., "EasyRCP.exe").
+        /// </summary>
+        [JsonPropertyName("name")]
+        public string? ApplicationName { get; set; }
+
+        /// <summary>
+        /// Gets or sets the download URL for the asset.
+        /// </summary>
+        [JsonPropertyName("browser_download_url")]
+        public string? AplicationDownloadUrl { get; set; }
+    }
+}

--- a/Services/RcpApiClient.cs
+++ b/Services/RcpApiClient.cs
@@ -183,12 +183,18 @@ public class RcpApiClient
         var rawHtml = parsed.RootElement.GetProperty("body").GetString();
         var readableHtml = WebUtility.HtmlDecode(rawHtml);
 
+        if (readableHtml == null)
+        {
+            return null;
+        }
+
         var match = Regex.Match(readableHtml, @"Ostatnia aktywność:</a><h3 class=""mb-2"">\s*Dzisiaj\s*(\d{2}:\d{2})\s*</h3>");
         if (match.Success && TimeSpan.TryParse(match.Groups[1].Value, CultureInfo.InvariantCulture, out var time))
         {
             var today = DateTime.Today.Add(time);
             return today;
         }
+
         return null;
     }
 


### PR DESCRIPTION
This pull request introduces an automatic update mechanism for the EasyRCP application, along with some additional improvements to the codebase. The key changes include implementing a GitHub-based update feature, integrating versioning tools, and refining error handling in existing methods.

### Automatic Update Mechanism:
* **New `GitHubUpdater` Service**: Added a new static class `GitHubUpdater` to check for and apply updates from GitHub Releases. It fetches the latest release, compares versions, downloads updates, and uses a batch script to replace the executable and restart the application (`Services/GitHubUpdater.cs`).
* **Integration with `Program.cs`**: The `Main` method now calls `GitHubUpdater.CheckVersionAndUpdateApplicationAsync()` to check for updates at startup (`Program.cs`).
* **Documentation Update**: Added a section in the `README.md` explaining the automatic update mechanism, including tools like `release-please` and `MinVer` for versioning (`README.md`).

### Versioning and Localization:
* **Project Configuration Updates**: 
  - Added `MinVer` for semantic versioning and configured its tag prefix.
  - Set the neutral language to Polish (`pl-PL`) in the project file (`EasyRCP.csproj`).
* **Added `MinVer` Dependency**: Included the `MinVer` NuGet package to manage application versioning (`EasyRCP.csproj`).

### Error Handling Improvement:
* **`CheckIfWorkAlreadyStarted` Method**: Improved error handling by adding a null check for `readableHtml` to prevent potential null reference exceptions (`Services/RcpApiClient.cs`).